### PR TITLE
add full controller layer for auth, user, job, and application endpoints

### DIFF
--- a/netmap-service/src/main/java/com/netmap/netmapservice/controller/ApplicationController.java
+++ b/netmap-service/src/main/java/com/netmap/netmapservice/controller/ApplicationController.java
@@ -1,0 +1,36 @@
+package com.netmap.netmapservice.controller;
+
+import com.netmap.netmapservice.domain.response.ApplicationResponse;
+import com.netmap.netmapservice.service.ApplicationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/applications")
+@RequiredArgsConstructor
+public class ApplicationController {
+
+    private final ApplicationService applicationService;
+
+    @PostMapping
+    public ResponseEntity<Void> apply(@RequestParam UUID jobSeekerId,
+                                      @RequestParam UUID jobPostingId) {
+        applicationService.applyToJob(jobSeekerId, jobPostingId);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/user/{id}")
+    public ResponseEntity<List<ApplicationResponse>> getUserApplications(@PathVariable UUID id) {
+        return ResponseEntity.ok(applicationService.getApplicationsByJobSeeker(id));
+    }
+
+    @GetMapping("/job/{id}")
+    public ResponseEntity<List<ApplicationResponse>> getApplicationsByJob(@PathVariable UUID id) {
+        return ResponseEntity.ok(applicationService.getApplicationsByJobPosting(id));
+    }
+
+}

--- a/netmap-service/src/main/java/com/netmap/netmapservice/controller/AuthController.java
+++ b/netmap-service/src/main/java/com/netmap/netmapservice/controller/AuthController.java
@@ -1,0 +1,27 @@
+package com.netmap.netmapservice.controller;
+
+import com.netmap.netmapservice.domain.request.LoginRequest;
+import com.netmap.netmapservice.domain.request.RegisterRequest;
+import com.netmap.netmapservice.domain.response.AuthResponse;
+import com.netmap.netmapservice.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthResponse> register(@RequestBody RegisterRequest request) {
+        return ResponseEntity.ok(authService.register(request));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+}

--- a/netmap-service/src/main/java/com/netmap/netmapservice/controller/JobController.java
+++ b/netmap-service/src/main/java/com/netmap/netmapservice/controller/JobController.java
@@ -1,0 +1,31 @@
+package com.netmap.netmapservice.controller;
+
+import com.netmap.netmapservice.domain.request.CreateJobRequest;
+import com.netmap.netmapservice.domain.response.JobPostResponse;
+import com.netmap.netmapservice.service.JobService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/jobs")
+@RequiredArgsConstructor
+public class JobController {
+
+    private final JobService jobService;
+
+    @PostMapping
+    public ResponseEntity<JobPostResponse> createJob(@RequestParam UUID employerId,
+                                                     @RequestBody CreateJobRequest request) {
+        return ResponseEntity.ok(jobService.createJob(employerId, request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<JobPostResponse>> listJobs() {
+        return ResponseEntity.ok(jobService.listAllJobs());
+    }
+
+}

--- a/netmap-service/src/main/java/com/netmap/netmapservice/controller/UserController.java
+++ b/netmap-service/src/main/java/com/netmap/netmapservice/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.netmap.netmapservice.controller;
+
+import com.netmap.netmapservice.domain.request.UpdateProfileRequest;
+import com.netmap.netmapservice.domain.response.ProfileResponse;
+import com.netmap.netmapservice.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProfileResponse> getProfile(@PathVariable UUID id) {
+        return ResponseEntity.ok(userService.getProfile(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updateProfile(@PathVariable UUID id,
+                                              @RequestBody UpdateProfileRequest request) {
+        userService.updateProfile(id, request);
+        return ResponseEntity.noContent().build();
+    }
+}


### PR DESCRIPTION
This PR implements the complete controller layer of the NetMap backend:

---

- [x] `AuthController`

  * `POST /auth/register` 
  * `POST /auth/login`

- [x] `UserController`

   * `GET /users/{id}`
   * `PUT /users/{id}`

- [x]  `JobController`

  * `POST /jobs?employerId=...`
  * `GET /jobs` 

- [x] `ApplicationController`

   * `POST /applications?jobSeekerId=...&jobPostingId=...`
   * `GET /applications/user/{id}`
   * `GET /applications/job/{id}`

- [x] Inject corresponding services

- [x] Use `@RestController`, `@RequestMapping`, `@PathVariable`, `@RequestBody`, etc.

- [x] Handle errors with basic `RuntimeException` (or later `@ControllerAdvice`)

---

Closes #9 
Closes #10 