### PR TITLE
Add ApplicationSummaryResponse DTO, mapper and user applications summary endpoint

### DIFF
--- a/netmap-service/src/main/java/com/netmap/netmapservice/controller/ApplicationController.java
+++ b/netmap-service/src/main/java/com/netmap/netmapservice/controller/ApplicationController.java
@@ -1,6 +1,7 @@
 package com.netmap.netmapservice.controller;
 
 import com.netmap.netmapservice.domain.response.ApplicationResponse;
+import com.netmap.netmapservice.domain.response.ApplicationSummaryResponse;
 import com.netmap.netmapservice.service.ApplicationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
+
 
 @RestController
 @RequestMapping("/applications")
@@ -24,8 +26,8 @@ public class ApplicationController {
     }
 
     @GetMapping("/user/{appUserId}")
-    public ResponseEntity<List<ApplicationResponse>> getUserApplications(@PathVariable UUID appUserId) {
-        return ResponseEntity.ok(applicationService.getApplicationsByJobSeeker(appUserId));
+    public ResponseEntity<List<ApplicationSummaryResponse>> getUserApplications(@PathVariable UUID appUserId) {
+        return ResponseEntity.ok(applicationService.getApplicationSummariesByUser(appUserId));
     }
 
     @GetMapping("/job/{jobPostingId}")

--- a/netmap-service/src/main/java/com/netmap/netmapservice/domain/response/ApplicationSummaryResponse.java
+++ b/netmap-service/src/main/java/com/netmap/netmapservice/domain/response/ApplicationSummaryResponse.java
@@ -1,0 +1,18 @@
+package com.netmap.netmapservice.domain.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+public class ApplicationSummaryResponse {
+    private UUID applicationId;
+    private UUID jobPostingId;
+    private String jobTitle;
+    private String companyName;
+    private String status;
+    private LocalDateTime applicationDate;
+}

--- a/netmap-service/src/main/java/com/netmap/netmapservice/mapper/ApplicationMapper.java
+++ b/netmap-service/src/main/java/com/netmap/netmapservice/mapper/ApplicationMapper.java
@@ -1,0 +1,22 @@
+package com.netmap.netmapservice.mapper;
+
+import com.netmap.netmapservice.domain.response.ApplicationSummaryResponse;
+import com.netmap.netmapservice.model.JobApplication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationMapper {
+
+    public ApplicationSummaryResponse toSummary(JobApplication app) {
+        return new ApplicationSummaryResponse(
+                app.getId(),
+                app.getJobPosting().getId(),
+                app.getJobPosting().getTitle(),
+                app.getJobPosting().getEmployer().getCompany() != null
+                        ? app.getJobPosting().getEmployer().getCompany().getName()
+                        : "Unknown Company",
+                app.getStatus().name(),
+                app.getApplicationDate()
+        );
+    }
+}

--- a/netmap-service/src/main/java/com/netmap/netmapservice/service/ApplicationService.java
+++ b/netmap-service/src/main/java/com/netmap/netmapservice/service/ApplicationService.java
@@ -1,6 +1,7 @@
 package com.netmap.netmapservice.service;
 
 import com.netmap.netmapservice.domain.response.ApplicationResponse;
+import com.netmap.netmapservice.domain.response.ApplicationSummaryResponse;
 
 import java.util.List;
 import java.util.UUID;
@@ -9,4 +10,5 @@ public interface ApplicationService {
     void applyToJob(UUID jobSeekerId, UUID jobPostingId);
     List<ApplicationResponse> getApplicationsByJobSeeker(UUID jobSeekerId);
     List<ApplicationResponse> getApplicationsByJobPosting(UUID jobPostingId);
+    List<ApplicationSummaryResponse> getApplicationSummariesByUser(UUID appUserId);
 }

--- a/netmap-service/src/main/java/com/netmap/netmapservice/service/impl/ApplicationServiceImpl.java
+++ b/netmap-service/src/main/java/com/netmap/netmapservice/service/impl/ApplicationServiceImpl.java
@@ -1,6 +1,8 @@
 package com.netmap.netmapservice.service.impl;
 
 import com.netmap.netmapservice.domain.response.ApplicationResponse;
+import com.netmap.netmapservice.domain.response.ApplicationSummaryResponse;
+import com.netmap.netmapservice.mapper.ApplicationMapper;
 import com.netmap.netmapservice.model.*;
 import com.netmap.netmapservice.repository.JobApplicationRepository;
 import com.netmap.netmapservice.repository.JobPostingRepository;
@@ -22,6 +24,7 @@ public class ApplicationServiceImpl implements ApplicationService {
     private final JobApplicationRepository jobApplicationRepository;
     private final JobPostingRepository jobPostingRepository;
     private final JobSeekerRepository jobSeekerRepository;
+    private final ApplicationMapper applicationMapper;
 
     @Override
     @Transactional
@@ -58,6 +61,15 @@ public class ApplicationServiceImpl implements ApplicationService {
 
         return jobApplicationRepository.findByJobPosting(jobPosting).stream()
                 .map(ApplicationResponse::new)
+                .collect(Collectors.toList());
+    }
+    @Override
+    public List<ApplicationSummaryResponse> getApplicationSummariesByUser(UUID appUserId) {
+        JobSeeker jobSeeker = jobSeekerRepository.findByAppUserId(appUserId)
+                .orElseThrow(() -> new RuntimeException("Job seeker not found"));
+
+        return jobApplicationRepository.findByJobSeeker(jobSeeker).stream()
+                .map(applicationMapper::toSummary)
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
This PR introduces a simplified representation of job applications for job seekers.

---

### ✳️ Tasks:

- [x]  `ApplicationSummaryResponse` DTO for lightweight application listings
- [x] `ApplicationMapper` to convert JobApplication → DTO
- [x] Service method to fetch applications in summary form
- [x] `/applications/user/{id}` endpoint now returns summaries instead of full details

---

This enables frontend to display user's job applications in a card/list format with minimal data.

Closes #27 
